### PR TITLE
pkg_path import fix

### DIFF
--- a/pywhiten/PyWhitener.py
+++ b/pywhiten/PyWhitener.py
@@ -42,7 +42,7 @@ class PyWhitener:
         # using this method to load the cfg maintains backwards compatibility with python 3.7 in the least painful form
         # load default cfg, then overwrite with config file specified by cfg
         pkg_path = pywhiten.pkg_path
-        default_config = pkg_path + "/cfg/default.toml"
+        default_config = pkg_path + "/default.toml"
         with open(default_config, "rb") as f:
             self.cfg = tomli.load(f)
 

--- a/pywhiten/__init__.py
+++ b/pywhiten/__init__.py
@@ -21,7 +21,6 @@ Variables:
     default_cfg (dict): A dictionary storing the default configuration
     pkg_path (string): A string storing the local path to the package
 """
-# import pywhiten.cfg
 from pywhiten.cfg import default_cfg, default_cfg_path, make_config_file, pkg_path
 import pywhiten.data
 import pywhiten.pwio

--- a/pywhiten/__init__.py
+++ b/pywhiten/__init__.py
@@ -21,7 +21,8 @@ Variables:
     default_cfg (dict): A dictionary storing the default configuration
     pkg_path (string): A string storing the local path to the package
 """
-import pywhiten.cfg
+# import pywhiten.cfg
+from pywhiten.cfg import default_cfg, default_cfg_path, make_config_file, pkg_path
 import pywhiten.data
 import pywhiten.pwio
 import pywhiten.optimization

--- a/pywhiten/__init__.py
+++ b/pywhiten/__init__.py
@@ -21,7 +21,7 @@ Variables:
     default_cfg (dict): A dictionary storing the default configuration
     pkg_path (string): A string storing the local path to the package
 """
-from pywhiten.cfg import default_cfg, default_cfg_path, make_config_file, pkg_path
+from pywhiten.cfg import *
 import pywhiten.data
 import pywhiten.pwio
 import pywhiten.optimization

--- a/pywhiten/cfg/__init__.py
+++ b/pywhiten/cfg/__init__.py
@@ -1,2 +1,2 @@
-from pywhiten.cfg.cfgutils import default_cfg, default_cfg_path, make_config_file
+from pywhiten.cfg.cfgutils import default_cfg, default_cfg_path, make_config_file, pkg_path
 


### PR DESCRIPTION
Should solve [this](https://github.com/erikstacey/pywhiten/issues/1#issue-1879602245) issue.

`pkg_path` was not imported from `cfg`

Also, in PyWhitener.py
`default_config = pkg_path + "/cfg/default.toml"` --> `default_config = pkg_path + "/default.toml"`
because `pkg_path` is the path to the `cfg` directory.